### PR TITLE
Fix linter warnings in Slider.jsx

### DIFF
--- a/frontend/src/js/itemCategory/Slider.jsx
+++ b/frontend/src/js/itemCategory/Slider.jsx
@@ -35,52 +35,53 @@ class Slider extends React.Component {
   }
 
   render () {
-       let settings = {
-       dots: true,
-       infinite: true,
-       centerMode: true,
-       arrows: true,
-       speed: 500,
-       slidesToShow: 5,
-       slidesToScroll: 2,
-       responsive: [
-         {
-           breakpoint: 700,
-           settings: {
-             slidesToShow: 1,
-             slidesToScroll: 1,
-             dots: false
-           }
-         },
-         {
-           breakpoint: 900,
-           settings: {
-             slidesToShow: 2,
-             slidesToScroll: 1
-           }
-         },
-         {
-           breakpoint: 860,
-           settings: {
-             slidesToShow: 2,
-             slidesToScroll: 1,
-             dots: false
-           }
-         },
-         {
-           breakpoint: 1100,
-           settings: {
-             slidesToShow: 3,
-             slidesToScroll: 1
-           }
-         },
-         {
-         breakpoint: 1300,
-         settings: {
-           slidesToShow: 4
-         }
-       }]
-     }
+    let settings = {
+      dots: true,
+      infinite: true,
+      centerMode: true,
+      arrows: true,
+      speed: 500,
+      slidesToShow: 5,
+      slidesToScroll: 2,
+      responsive: [
+        {
+          breakpoint: 700,
+          settings: {
+            slidesToShow: 1,
+            slidesToScroll: 1,
+            dots: false
+          }
+        },
+        {
+          breakpoint: 900,
+          settings: {
+            slidesToShow: 2,
+            slidesToScroll: 1
+          }
+        },
+        {
+          breakpoint: 860,
+          settings: {
+            slidesToShow: 2,
+            slidesToScroll: 1,
+            dots: false
+          }
+        },
+        {
+          breakpoint: 1100,
+          settings: {
+            slidesToShow: 3,
+            slidesToScroll: 1
+          }
+        },
+        {
+          breakpoint: 1300,
+          settings: {
+            slidesToShow: 4
+          }
+        }
+      ]
+    }
 
     const returnItemJSX = (item) => {
       return (


### PR DESCRIPTION
@Virginie-T somehow you managed to commit code that failed the pre-commit hook...did you have it disabled? Your indentations were slightly off.
