### PR TITLE
small fix for populateDB handler

### DIFF
--- a/backend/lib/server.js
+++ b/backend/lib/server.js
@@ -38,7 +38,13 @@ server.register(plugins, (err) => {
       path: '/populateDB',
       handler: (request, reply) => {
         const client = require('./redis.js')
-        require('./populateDB/populateDB.js')(client)
+        client.SINTER('global', (err, reply) => {
+          if (err) {
+            console.log(err)
+          } else if (reply.length === 0) {
+            require('./populateDB/populateDB.js')(client)
+          }
+        })
         reply.redirect('/')
       }
     }, {


### PR DESCRIPTION
Now you can only populate the database if the database is empty. So that we don't end up with duplicated products if someone goes to the /populateDB endpoint multiple times.
